### PR TITLE
Ansible apt_repository failure on cloud-archive:queens

### DIFF
--- a/play/install_pkg.yml
+++ b/play/install_pkg.yml
@@ -8,5 +8,6 @@
 
 - name: Install queens cloud-archive
   apt_repository:
-    name: cloud-archives:queens
-    update_cache: yes
+    repo: deb http://ubuntu-cloud.archive.canonical.com/ubuntu xenial-updates/queens main
+    state: present
+    filename: queens


### PR DESCRIPTION
Ansible apt_repository fails to add repo cloud-archive:queens.
Instead of that we need this work out.